### PR TITLE
feat: Add security headers to multiple PHP files

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+  session_start();
+  require 'includes/security-headers.php';
 
   $returnError = $_GET['error'] ?? null;
   if ($returnError == 'notfound') {

--- a/bluemap.php
+++ b/bluemap.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+  session_start();
+  require 'includes/security-headers.php';
 ?>
 
 <!doctype html>

--- a/contact.php
+++ b/contact.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+  session_start();
+  require 'includes/security-headers.php';
+
 ?>
 
 <!doctype html>

--- a/faq.php
+++ b/faq.php
@@ -1,5 +1,7 @@
 <?php
     session_start();
+    require 'includes/security-headers.php';
+    
     $requestedTopic = $_GET['topic'] ?? '';
 
     $data = json_decode(file_get_contents('data/faq.json'), true);

--- a/help-and-support.php
+++ b/help-and-support.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+    session_start();
+    require 'includes/security-headers.php';
 ?>
 
 <!doctype html>

--- a/includes/security-headers.php
+++ b/includes/security-headers.php
@@ -1,0 +1,8 @@
+<?php
+header("Strict-Transport-Security: max-age=31536000; includeSubDomains");
+// header("Content-Security-Policy: default-src 'self'");
+header("X-Frame-Options: SAMEORIGIN");
+header("X-Content-Type-Options: nosniff");
+header("Referrer-Policy: no-referrer-when-downgrade");
+header("Permissions-Policy: geolocation=(), microphone=()");
+?>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
     session_start();
-    include 'functions/connect.php';
+    require 'includes/security-headers.php';
+    require 'functions/connect.php';
 
     $spotlightStmt = $conn->prepare("SELECT * FROM articles WHERE spotlight = 1 ORDER BY date_posted DESC LIMIT 1");
     $spotlightStmt->execute();

--- a/news.php
+++ b/news.php
@@ -1,6 +1,7 @@
 <?php
     session_start();
-    include 'functions/connect.php';
+    require 'includes/security-headers.php';
+    require 'functions/connect.php';
 
     $stmt = $conn->prepare("SELECT * FROM articles ORDER BY date_posted DESC");
     $stmt->execute();

--- a/news/article.php
+++ b/news/article.php
@@ -1,6 +1,7 @@
 <?php
     session_start();
-    include '../functions/connect.php';
+    require '../includes/security-headers.php';
+    require '../functions/connect.php';
 
     $id = $_GET['id'] ?? '';
     $stmt = $conn->prepare("SELECT * FROM articles WHERE id = ?");

--- a/news/editor.php
+++ b/news/editor.php
@@ -1,5 +1,7 @@
 <?php
     session_start();
+    require '../includes/security-headers.php';
+
 
     if (isset($_SESSION['permission_level']) && $_SESSION['permission_level'] == 1) {
         include '../functions/connect.php';

--- a/profile.php
+++ b/profile.php
@@ -1,4 +1,6 @@
 <?php
+    require 'includes/security-headers.php';
+
     session_start();
     if (!isset($_SESSION['user_id'])) {
         header('Location: pages/login.php');

--- a/rules.php
+++ b/rules.php
@@ -1,5 +1,7 @@
 <?php
   session_start();
+  require 'includes/security-headers.php';
+  
   $page = $_GET['page'] ?? 'home';
   $rules = json_decode(file_get_contents('data/rules.json'), true);
 


### PR DESCRIPTION
This update adds essential HTTP security headers to enhance browser-side security and reduce potential attack vectors. The following headers were added at the top of key PHP files:

- Strict-Transport-Security
- X-Frame-Options
- X-Content-Type-Options
- Referrer-Policy
- Permissions-Policy